### PR TITLE
Module recovery, walkthrough first config save

### DIFF
--- a/node-operators/hyperdrive/configuration.md
+++ b/node-operators/hyperdrive/configuration.md
@@ -39,3 +39,33 @@ With [Grafana](https://grafana.com/) and [Prometheus](https://prometheus.io/) bu
 #### Hyperdrive and TX Fees
 
 Hyperdrive allows users to control manual and automatic transaction settings. In the configuration TUI, you can set the maximum gas, priority fees, and other details to ensure your node operates profitably.
+
+#### Configuration Wizard - Savings Settings
+
+In the last step of the configuration wizard, you can Review All Changes, or simply Save and Exit.  After saving and exiting the wizard, you can start Hyperdrive services.  
+
+`Would you like to start the Hyperdrive services automatically now? [y/n]`
+
+Based on new configuration, Hyperdrive sees that you haven't started the Validator Client before. To be sure, Hyperdrive asks you to confirm there are no active validators. If this is truly a new install on a fresh system, it's safe to say `y` here.
+
+`It looks like this is your first time starting a Validator Client.
+Just to be sure, does your node have any existing, active validators attesting on the Beacon Chain? [y/n]`
+
+There is a final warning, because Hyperdrive can't determine if you may have been attesting in the last 15 minutes. Again, in a fresh install, it's safe to say `y`.
+
+```
+Since your node didn't have any Validator Clients before, Hyperdrive can't determine if you attested in the last 15 minutes.
+If you did, it may resubmit an attestation you have already submitted.
+This will slash your validator!
+To prevent slashing, you must wait 15 minutes from the time you stopped the clients before starting them again.
+
+Press y when you understand the above warning, have waited, and are ready to start Hyperdrive: [y/n]
+```
+
+At this point, the Hyperdrive docker containers will start. The particular containers started will depend upon configuration.
+
+#### Creating the Hyperdrive node wallet
+
+After the containers start, Hyperdrive will check your wallet status. In a fresh install, it detects you don't have a wallet and offers to create one. In a typical install you'd say `y`. If this install is part of disaster recovery, choose `n`, as you'll use the recover wallet command instead.
+
+Hyperdrive then walks you through creation of the wallet, presenting the mnemonic, and testing to ensure you saved it.

--- a/node-operators/hyperdrive/configuration.md
+++ b/node-operators/hyperdrive/configuration.md
@@ -46,12 +46,12 @@ In the last step of the configuration wizard, you can Review All Changes, or sim
 
 `Would you like to start the Hyperdrive services automatically now? [y/n]`
 
-Based on new configuration, Hyperdrive sees that you haven't started the Validator Client before. To be sure, Hyperdrive asks you to confirm there are no active validators. If this is truly a new install on a fresh system, it's safe to say `y` here.
+Most users should reply `y` to this.
 
 `It looks like this is your first time starting a Validator Client.
 Just to be sure, does your node have any existing, active validators attesting on the Beacon Chain? [y/n]`
 
-There is a final warning, because Hyperdrive can't determine if you may have been attesting in the last 15 minutes. Again, in a fresh install, it's safe to say `y`.
+Based on new configuration, Hyperdrive sees that you haven't started the Validator Client before. To be sure, Hyperdrive asks you to confirm there are no active validators. If this is truly a new install on a fresh system, it's safe to say `y` here.
 
 ```
 Since your node didn't have any Validator Clients before, Hyperdrive can't determine if you attested in the last 15 minutes.
@@ -62,10 +62,12 @@ To prevent slashing, you must wait 15 minutes from the time you stopped the clie
 Press y when you understand the above warning, have waited, and are ready to start Hyperdrive: [y/n]
 ```
 
+There is a final warning, because Hyperdrive can't determine if you may have been attesting in the last 15 minutes. Again, in a fresh install, it's safe to say `y`.
+
 At this point, the Hyperdrive docker containers will start. The particular containers started will depend upon configuration.
 
 #### Creating the Hyperdrive node wallet
 
-After the containers start, Hyperdrive will check your wallet status. In a fresh install, it detects you don't have a wallet and offers to create one. In a typical install you'd say `y`. If this install is part of disaster recovery, choose `n`, as you'll use the recover wallet command instead.
+After the containers start, Hyperdrive will check your wallet status. In a fresh installation, it detects that you don't have a wallet and offers to create one. For a new install, respond with `y`. If this installation is part of disaster recovery or migration, choose `n`, as you'll use the recover wallet command instead.
 
 Hyperdrive then walks you through creation of the wallet, presenting the mnemonic, and testing to ensure you saved it.

--- a/node-operators/hyperdrive/disaster-recovery-and-node-migration.md
+++ b/node-operators/hyperdrive/disaster-recovery-and-node-migration.md
@@ -38,9 +38,59 @@ Wallet recovery is the process for restoring a node from an offline seed phrase 
 To minimize downtime, you should initiate a wallet recovery on new hardware **as soon as you realize the old filesystem is not recoverable.**
 {% endhint %}
 
-First, [install Hyperdrive as usual](installation.md) on your new node.&#x20;
+First, [install Hyperdrive as usual](installation.md) on your new node. When Hyperdrive asks you to create a wallet, reply `n`. This will save you the step of creating and validating a new mnemonic which won't be used. 
 
 Next, use the `hyperdrive wallet recover` command to regenerate your node wallet based on your seed phrase backup. From here, you should review your configuration with `hyperdrive service config` and [monitor the node as usual](monitoring-your-node.md) to ensure it is operational.
+
+### Recovering the StakeWise Module
+
+After you've recovered your wallet, you can enable the StakeWise module in the Hyperdrive Configuration terminal `hyperdrive service config` -> Modules menu.
+
+After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, ensure that the node you're recovering hasn't attested in the last 15 minutes.
+
+After you've enabled the StakeWise module, you need to regenerate your validator keys. The reason for this is that the new Hyperdrive installation currently has no way of knowing how many keys were generated before. Regenerate the same number of keys with `hyperdrive stakewise wallet generate -c X` where `X` is the number of keys to generate. The alias version of this command is `hyperdrive sw w g -c X`.
+
+Hyperdrive will ask if you want to continue uploading your deposit data. Even though it's already been uploaded, it's safe to do this, as Hyperdrive will detect they've already been uploaded, and report back the status.
+
+```
+NOTE: There is currently no way to remove a validator's deposit data from the NodeSet service once you've uploaded it. The key will be eligible for activation at any time, so this node must remain online at all times to handle activation and validation duties.
+If you turn the node off, you may be removed from NodeSet for negligence of duty!
+
+Do you want to continue uploading your deposit data? [y/n]
+y
+
+Uploading deposit data to the NodeSet server...
+All of your validator keys are already registered (10 in total).
+7 are pending activation.
+3 have been activated already.
+```
+
+### Recovering the Constellation Module
+
+After you've recovered your wallet, you can enable the Constellation module in the Hyperdrive Configuration terminal `hyperdrive service config` -> Modules menu.
+
+After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, ensure that the node you're recovering hasn't attested in the last 15 minutes.
+
+After you've enabled the Constellation module, you need to rebuild your validator keys. The Constellation module searches for activated keys from the Constellation wallet derivation path, by default from index 0 to index 500. You can rebuild your validator keys with `hyperdrive constellation wallet rebuild`. The alias version of this command is `hyperdrive cs w b`.
+
+```
+The following keys will be rebuilt:
+        Minipool: 0xeDa3C8D065B97609Be536bF54fEC757D11D79CD5
+        Validator: 0x992b0131967c3bd4e840075e2189c7a6836c5b858ee964e4fdd05a1d3230d9668259fdb3651b5ef63bad06e17b37b330
+        Index: 1814204
+
+Are you ready to rebuild these keys? [y/n]
+y
+
+Rebuilding 0x992b0131967c3bd4e840075e2189c7a6836c5b858ee964e4fdd05a1d3230d9668259fdb3651b5ef63bad06e17b37b330... done! (2.228147452s)
+1 keys have been rebuilt.
+
+Your Constellation Validator Client must be restarted in order to load the validator keys and resume attesting wth them.
+Would you like to restart the Constellation Validator Client now? [y/n]
+y
+
+Successfully restarted the Constellation Validator Client. Your rebuilt validator keys are now loaded.
+```
 
 ## Lost Seed Phrase
 

--- a/node-operators/hyperdrive/disaster-recovery-and-node-migration.md
+++ b/node-operators/hyperdrive/disaster-recovery-and-node-migration.md
@@ -46,11 +46,7 @@ Next, use the `hyperdrive wallet recover` command to regenerate your node wallet
 
 After you've recovered your wallet, you can enable the StakeWise module in the Hyperdrive Configuration terminal `hyperdrive service config` -> Modules menu.
 
-After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, ensure that the node you're recovering hasn't attested in the last 15 minutes.
-
-After you've enabled the StakeWise module, you need to regenerate your validator keys. The reason for this is that the new Hyperdrive installation currently has no way of knowing how many keys were generated before. Regenerate the same number of keys with `hyperdrive stakewise wallet generate -c X` where `X` is the number of keys to generate. The alias version of this command is `hyperdrive sw w g -c X`.
-
-Hyperdrive will ask if you want to continue uploading your deposit data. Even though it's already been uploaded, it's safe to do this, as Hyperdrive will detect they've already been uploaded, and report back the status.
+After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, this will apply to you, and **you MUST ensure that the node you're recovering hasn't attested in the last 15 minutes or you may be slashed!**
 
 ```
 NOTE: There is currently no way to remove a validator's deposit data from the NodeSet service once you've uploaded it. The key will be eligible for activation at any time, so this node must remain online at all times to handle activation and validation duties.
@@ -65,13 +61,15 @@ All of your validator keys are already registered (10 in total).
 3 have been activated already.
 ```
 
+After you've enabled the StakeWise module, you need to regenerate your validator keys. The reason for this is that the new Hyperdrive installation currently has no way of knowing how many keys were generated before. Regenerate the same number of keys with `hyperdrive stakewise wallet generate -c X` where `X` is the number of keys to generate. The alias version of this command is `hyperdrive sw w g -c X`.
+
+Hyperdrive will ask if you want to continue uploading your deposit data. Even though it's already been uploaded, it's safe to do this, as Hyperdrive will detect they've already been uploaded, and report back the status.
+
 ### Recovering the Constellation Module
 
 After you've recovered your wallet, you can enable the Constellation module in the Hyperdrive Configuration terminal `hyperdrive service config` -> Modules menu.
 
-After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, ensure that the node you're recovering hasn't attested in the last 15 minutes.
-
-After you've enabled the Constellation module, you need to rebuild your validator keys. The Constellation module searches for activated keys from the Constellation wallet derivation path, by default from index 0 to index 500. You can rebuild your validator keys with `hyperdrive constellation wallet rebuild`. The alias version of this command is `hyperdrive cs w b`.
+After exiting the configuration terminal, Hyperdrive asks you to verify you don't have any running validators, and a final verification that if you did have validators running, you've waited 15 minutes, because Hyperdrive can't determine if you attested in the last 15 minutes. Because you're about to regenerate the same keys, this will apply to you, and **you MUST ensure that the node you're recovering hasn't attested in the last 15 minutes or you may be slashed!**
 
 ```
 The following keys will be rebuilt:
@@ -91,6 +89,8 @@ y
 
 Successfully restarted the Constellation Validator Client. Your rebuilt validator keys are now loaded.
 ```
+
+After you've enabled the Constellation module, you need to rebuild your validator keys. The Constellation module searches for activated keys from the Constellation wallet derivation path, by default from index 0 to index 500. You can rebuild your validator keys with `hyperdrive constellation wallet rebuild`. The alias version of this command is `hyperdrive cs w b`.
 
 ## Lost Seed Phrase
 


### PR DESCRIPTION
Added section for walkthrough after config wizard save, consisting of wallet init or skipping in lieu of wallet recovery.

Added sections for module recovery steps.