### PR TITLE
fix the register node command

### DIFF
--- a/nodeset-dashboard/authorizing-your-node.md
+++ b/nodeset-dashboard/authorizing-your-node.md
@@ -7,7 +7,7 @@ Before operators can connect their nodes and earn rewards, they must first [crea
 To connect your node to your NodeSet account, follow the steps listed here.&#x20;
 
 1. Use the [Node Addresses](https://www.nodeset.io/dashboard/node-addresses) page to whitelist your node address by adding it as a pending node address. You may add any Ethereum address and any number of them, but these will only become registered and connected after verification of ownership in the next step.
-2. In Hyperdrive, use the `hyperdrive stakewise nodeset register-node` command to register the node. This will prompt you to enter the email address you used to create your NodeSet account, then it will automatically confirm your ownership of the node's private key and authorize its use with your NodeSet account.
+2. In Hyperdrive, use the `hyperdrive nodeset register-node` command to register the node. This will prompt you to enter the email address you used to create your NodeSet account, then it will automatically confirm your ownership of the node's private key and authorize its use with your NodeSet account.
 
 Once you've successfully authorized your node, Hyperdrive's full capabilities are unlocked and you will see that node address in the list of authorized nodes on the dashboard.
 


### PR DESCRIPTION
The authorizing your node docs page has a wrong/ outdated command:

`hyperdrive stakewise nodeset register-node` => should be => `hyperdrive nodeset register-node`

https://docs.nodeset.io/nodeset-dashboard/authorizing-your-node

![image](https://github.com/user-attachments/assets/7642ad34-d5d5-48d8-ae79-6a0d02e9a1ee)
